### PR TITLE
Remove already injected html before inject script again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,7 @@
         "type": "boolean",
         "access": "public",
         "title": "Use staging scripts",
-        "default": "true"
+        "default": true
       }
     }
   },

--- a/react/services/ScriptHandler.jsx
+++ b/react/services/ScriptHandler.jsx
@@ -33,6 +33,13 @@ export const setProduct = ({ productId, productName, imageUrl, productReference,
   if (window._trustvox_initializer) window._trustvox_initializer.initialize();
 }
 
+export const cleanUpScript = () => {
+  const rateContainer = document.querySelector('.ts-shelf-container');
+  if(rateContainer){
+    rateContainer.remove();
+  }
+}
+
 export const injectMainScript = () => {
   // Main script
   if (!document.querySelector('#trustvox_script_main')) {
@@ -48,6 +55,7 @@ export const injectMainScript = () => {
 }
 
 export const injectWidgetScripts = () => {
+  cleanUpScript();
   injectMainScript();
 
   // All scripts


### PR DESCRIPTION
Aparentemente, o script da Trustvox valida se ja existe um HTML inserido
`document.querySelector('.ts-shelf-container')`

Então valido se ele ja esta inserido, e caso sim, eu removo ele antes de inserir novamente os scripts, dando cleanup como explica na parte de SPA da documentacão:  https://help.trustvox.com.br/pt-BR/articles/5557705-como-exibir-as-opinioes-e-adicionar-os-scripts-da-ra-trustvox-de-forma-generica