### PR TITLE
Update data-trustvox-display-rate-schema to false

### DIFF
--- a/react/RatingSummary.jsx
+++ b/react/RatingSummary.jsx
@@ -37,7 +37,7 @@ const RatingSummary = () => {
           className="trustvox-shelf-container"
           data-trustvox-product-code-js={productId}
           data-trustvox-should-skip-filter="true"
-          data-trustvox-display-rate-schema="true"
+          data-trustvox-display-rate-schema="false"
         />
         <span className="rating-click-here">
           <FormattedMessage


### PR DESCRIPTION
As the data structured in VTEX is in JSON-LD, it makes no sense to have the aggregateRating in microdata in the Rate Widget. Changing the "data-trustvox-display-rate-schema" property to false, this microdata is no longer generated.