### PR TITLE
Set productId to String

### DIFF
--- a/react/services/ScriptHandler.jsx
+++ b/react/services/ScriptHandler.jsx
@@ -3,7 +3,7 @@ export const setProduct = ({ productId, productName, imageUrl, productReference,
   if (window._trustvox &&
     window._trustvox.find(i => i[0] === '_productId') &&
     window._trustvox.find(i => i[0] === '_productId')[1] &&
-    window._trustvox.find(i => i[0] === '_productId')[1] === productId) {
+    window._trustvox.find(i => i[0] === '_productId')[1] === String(productId)) {
     return null
   }
 


### PR DESCRIPTION
The VTEX.IO platform returns the productID as a string. The change aims to ensure that the value is validated as a string, enforcing this validation.